### PR TITLE
*NIX compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ set(CMAKE_CXX_STANDARD 14)
 set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
-find_package(Boost COMPONENTS filesystem REQUIRED)
 
 option(BUILD_EXAMPLES "build examples" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(GridGraph)
 
 #GLOBALS
 set(CMAKE_CXX_STANDARD 14)
-set(OPTS -march=native -Wall -Wextra  -Wno-unused-parameter -O3)
+set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused-parameter -O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
 find_package(Boost COMPONENTS filesystem REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,20 @@ project(GridGraph)
 
 #GLOBALS
 set(CMAKE_CXX_STANDARD 14)
-set(OPTS -march=native -Wall -Wextra -Werror -O3)
+set(OPTS -march=native -Wall -Wextra -O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
+find_package(Boost COMPONENTS filesystem REQUIRED)
 
 option(BUILD_EXAMPLES "build examples" ON)
-option(USE_OPENMP "use OpenMP multithreading" ON)
 
 add_subdirectory(tools)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_definitions(-DLINUX)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_definitions(-DDARWIN)
+endif ()
 
 if (BUILD_EXAMPLES)
     add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(GridGraph)
 
 #GLOBALS
 set(CMAKE_CXX_STANDARD 14)
-set(OPTS -march=native -Wall -Wextra -Wno-unused-parameter -O3)
+set(OPTS -march=native -Wall -Wextra  -Wno-unused-parameter -O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
 find_package(Boost COMPONENTS filesystem REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(GridGraph)
 
 #GLOBALS
 set(CMAKE_CXX_STANDARD 14)
-set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused-parameter -O3)
+set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
 find_package(Boost COMPONENTS filesystem REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(GridGraph)
 
 #GLOBALS
 set(CMAKE_CXX_STANDARD 14)
-set(OPTS -march=native -Wall -Wextra -O3)
+set(OPTS -march=native -Wall -Wextra -Wno-unused-parameter -O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
 find_package(Boost COMPONENTS filesystem REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.9)
 project(GridGraph)
 
 #GLOBALS
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(OPTS -march=native;-Wall;-Wextra;-Werror;-Wno-unused;-Wno-unused-parameter;-O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(GridGraph)
 
 #GLOBALS
 set(CMAKE_CXX_STANDARD 14)
-set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused -Wno-unused -O3)
+set(OPTS -march=native;-Wall;-Wextra;-Werror;-Wno-unused;-Wno-unused-parameter;-O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-v
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
 
+#OUTPUT DIR
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 option(BUILD_EXAMPLES "build examples" ON)
 
 add_subdirectory(tools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(GridGraph)
 
 #GLOBALS
 set(CMAKE_CXX_STANDARD 14)
-set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-variable -O3)
+set(OPTS -march=native -Wall -Wextra -Werror -Wno-unused -Wno-unused -O3)
 file(GLOB CORE_HEADERS "core/*.hpp")
 find_package(Threads REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+#[[Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.]]
+
+cmake_minimum_required(VERSION 3.9)
+project(GridGraph)
+
+#GLOBALS
+set(CMAKE_CXX_STANDARD 14)
+set(OPTS -march=native -Wall -Wextra -Werror -O3)
+file(GLOB CORE_HEADERS "core/*.hpp")
+find_package(Threads REQUIRED)
+
+option(BUILD_EXAMPLES "build examples" ON)
+option(USE_OPENMP "use OpenMP multithreading" ON)
+
+add_subdirectory(tools)
+
+if (BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif ()

--- a/core/atomic.hpp
+++ b/core/atomic.hpp
@@ -20,13 +20,14 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <atomic>
 
 template <class ET>
 inline bool cas(ET *ptr, ET oldv, ET newv) {
-	if (sizeof(ET) == 8) {
-		return __sync_bool_compare_and_swap((long*)ptr, *((long*)&oldv), *((long*)&newv));
-	} else if (sizeof(ET) == 4) {
-		return __sync_bool_compare_and_swap((int*)ptr, *((int*)&oldv), *((int*)&newv));
+	if (sizeof(ET) == sizeof(uint64_t)) {
+		return __sync_bool_compare_and_swap((uint64_t*)ptr, (uint64_t)oldv, (uint64_t)newv);
+	} else if (sizeof(ET) == sizeof(uint32_t)) {
+		return __sync_bool_compare_and_swap((uint32_t*)ptr, (uint32_t)oldv, (uint32_t)newv);
 	} else {
 		assert(false);
 	}

--- a/core/atomic.hpp
+++ b/core/atomic.hpp
@@ -48,4 +48,12 @@ inline void write_add(ET *a, ET b) {
 	while (!cas(a, oldV, newV));
 }
 
+inline void *memalign(size_t alignment, size_t size) {
+	void *ret;
+	if (posix_memalign(&ret, alignment, size) != 0) {
+		ret = nullptr;
+	};
+	return ret;
+}
+
 #endif

--- a/core/atomic.hpp
+++ b/core/atomic.hpp
@@ -18,8 +18,8 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #define ATOMIC_H
 
 #include <cstdio>
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cassert>
 
 template <class ET>
 inline bool cas(ET *ptr, ET oldv, ET newv) {

--- a/core/atomic.hpp
+++ b/core/atomic.hpp
@@ -17,10 +17,9 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #ifndef ATOMIC_H
 #define ATOMIC_H
 
-#include <stdio.h>
+#include <cstdio>
 #include <stdlib.h>
 #include <assert.h>
-#include <atomic>
 
 template <class ET>
 inline bool cas(ET *ptr, ET oldv, ET newv) {

--- a/core/bigvector.hpp
+++ b/core/bigvector.hpp
@@ -90,7 +90,7 @@ public:
 			}
 			close(fout);
 		}
-		fd = open(path.c_str(), O_RDWR | O_DIRECT);
+		fd = open(path.c_str(), O_RDWR | O_SYNC);
 		assert(fd!=-1);
 		open_mmap();
 	}

--- a/core/bigvector.hpp
+++ b/core/bigvector.hpp
@@ -74,7 +74,7 @@ public:
 			FILE * fout = fopen(path.c_str(), "wb");
 			fclose(fout);
 		}
-		if (file_size(path) != sizeof(T) * length) {
+		if (static_cast<unsigned>(file_size(path)) != sizeof(T) * length) {
 			long file_length = sizeof(T) * length;
 			assert(truncate(path.c_str(), file_length)!=-1);
 			int fout = open(path.c_str(), O_WRONLY);

--- a/core/bigvector.hpp
+++ b/core/bigvector.hpp
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
+Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/bigvector.hpp
+++ b/core/bigvector.hpp
@@ -17,16 +17,21 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #ifndef BIGVECTOR_H
 #define BIGVECTOR_H
 
-#include <assert.h>
+#include <cassert>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/mman.h>
+#ifdef USE_OPENMP
 #include <omp.h>
+#endif
 
 #include <thread>
+#include <string>
 
 #include "core/filesystem.hpp"
 #include "core/partition.hpp"
+
+#define memalign(alignment, size) malloc(size)
 
 template <typename T>
 class BigVector {
@@ -90,8 +95,8 @@ public:
 		open_mmap();
 	}
 	void open_mmap() {
-		int ret = posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
-		assert(ret==0);
+		//int ret = posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL); //This is mostly useless on modern system
+		//assert(ret==0);
 		data = (T *)mmap(NULL, sizeof(T) * length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 		assert(data!=MAP_FAILED);
 		is_open = true;

--- a/core/bigvector.hpp
+++ b/core/bigvector.hpp
@@ -31,6 +31,7 @@ Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 
 #include "core/filesystem.hpp"
 #include "core/partition.hpp"
+#include "core/atomic.hpp"
 
 template <typename T>
 class BigVector {

--- a/core/bigvector.hpp
+++ b/core/bigvector.hpp
@@ -32,7 +32,13 @@ Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 #include "core/filesystem.hpp"
 #include "core/partition.hpp"
 
-#define memalign(alignment, size) malloc(size)
+void *memalign(size_t alignment, size_t size) {
+	void *ret;
+	if (posix_memalign(&ret, alignment, size) != 0) {
+	    ret = nullptr;
+	};
+	return ret;
+}
 
 template <typename T>
 class BigVector {

--- a/core/bigvector.hpp
+++ b/core/bigvector.hpp
@@ -32,14 +32,6 @@ Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 #include "core/filesystem.hpp"
 #include "core/partition.hpp"
 
-void *memalign(size_t alignment, size_t size) {
-	void *ret;
-	if (posix_memalign(&ret, alignment, size) != 0) {
-	    ret = nullptr;
-	};
-	return ret;
-}
-
 template <typename T>
 class BigVector {
 	std::string path;

--- a/core/bitmap.hpp
+++ b/core/bitmap.hpp
@@ -17,6 +17,8 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #ifndef BITMAP_H
 #define BITMAP_H
 
+#include <cstddef>
+
 #define WORD_OFFSET(i) (i >> 6)
 #define BIT_OFFSET(i) (i & 0x3f)
 

--- a/core/filesystem.hpp
+++ b/core/filesystem.hpp
@@ -19,7 +19,8 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <errno.h>
+#include <cerrno>
+#include <string>
 
 inline bool file_exists(std::string filename) {
 	struct stat st;

--- a/core/filesystem.hpp
+++ b/core/filesystem.hpp
@@ -29,12 +29,14 @@ inline bool file_exists(std::string filename) {
 
 inline long file_size(std::string filename) {
 	struct stat st;
-	assert(stat(filename.c_str(), &st)==0);
+	auto ret = stat(filename.c_str(), &st);
+	assert(ret == 0);
 	return st.st_size;
 }
 
 inline void create_directory(std::string path) {
-	assert(mkdir(path.c_str(), 0764)==0 || errno==EEXIST);
+	auto ret = mkdir(path.c_str(), 0764);
+	assert(ret == 0 || errno == EEXIST);
 }
 
 // TODO: only on unix-like systems

--- a/core/graph.hpp
+++ b/core/graph.hpp
@@ -17,9 +17,9 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #ifndef GRAPH_H
 #define GRAPH_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
 #include <unistd.h>
 #ifdef USE_OPENMP
 #include <omp.h>
@@ -322,7 +322,7 @@ public:
 				}, ti);
 			}
 			fin = open((path+"/row").c_str(), read_mode);
-			posix_fadvise(fin, 0, 0, POSIX_FADV_SEQUENTIAL);
+			//posix_fadvise(fin, 0, 0, POSIX_FADV_SEQUENTIAL); //This is mostly useless on modern system
 			for (int i=0;i<partitions;i++) {
 				if (!should_access_shard[i]) continue;
 				for (int j=0;j<partitions;j++) {
@@ -351,7 +351,7 @@ public:
 			break;
 		case 1: // target oriented update
 			fin = open((path+"/column").c_str(), read_mode);
-			posix_fadvise(fin, 0, 0, POSIX_FADV_SEQUENTIAL);
+			//posix_fadvise(fin, 0, 0, POSIX_FADV_SEQUENTIAL); //This is mostly useless on modern system
 
 			for (int cur_partition=0;cur_partition<partitions;cur_partition+=partition_batch) {
 				VertexId begin_vid, end_vid;

--- a/core/graph.hpp
+++ b/core/graph.hpp
@@ -284,7 +284,7 @@ public:
 		}
 		int read_mode;
 		if (memory_bytes < total_bytes) {
-			read_mode = O_RDONLY | O_DIRECT;
+			read_mode = O_RDONLY | O_SYNC;
 			// printf("use direct I/O\n");
 		} else {
 			read_mode = O_RDONLY;

--- a/core/graph.hpp
+++ b/core/graph.hpp
@@ -21,9 +21,10 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #include <stdlib.h>
 #include <math.h>
 #include <unistd.h>
-#include <malloc.h>
+#ifdef USE_OPENMP
 #include <omp.h>
-#include <string.h>
+#endif
+#include <cstring>
 
 #include <thread>
 #include <vector>

--- a/core/graph.hpp
+++ b/core/graph.hpp
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
+Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/graph.hpp
+++ b/core/graph.hpp
@@ -131,13 +131,13 @@ public:
 		column_offset = new long [partitions*partitions+1];
 		int fin_column_offset = open((path+"/column_offset").c_str(), O_RDONLY);
 		bytes = read(fin_column_offset, column_offset, sizeof(long)*(partitions*partitions+1));
-		assert(bytes==sizeof(long)*(partitions*partitions+1));
+		assert(bytes==static_cast<unsigned>(sizeof(long)*(partitions*partitions+1)));
 		close(fin_column_offset);
 
 		row_offset = new long [partitions*partitions+1];
 		int fin_row_offset = open((path+"/row_offset").c_str(), O_RDONLY);
 		bytes = read(fin_row_offset, row_offset, sizeof(long)*(partitions*partitions+1));
-		assert(bytes==sizeof(long)*(partitions*partitions+1));
+		assert(bytes==static_cast<unsigned>(sizeof(long)*(partitions*partitions+1)));
 		close(fin_row_offset);
 	}
 

--- a/core/graph.hpp
+++ b/core/graph.hpp
@@ -29,6 +29,7 @@ Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 
 #include <thread>
 #include <vector>
+#include <functional>
 
 #include "core/constants.hpp"
 #include "core/type.hpp"

--- a/core/partition.hpp
+++ b/core/partition.hpp
@@ -17,6 +17,9 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #ifndef PARTITION_H
 #define PARTITION_H
 
+#include <cstddef>
+#include <utility>
+
 inline size_t get_partition_id(const size_t vertices, const size_t partitions, const size_t vertex_id) {
         if (vertices % partitions==0) {
                 const size_t partition_size = vertices / partitions;

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,12 +28,12 @@ foreach(EXAMPLE_SRC ${EXAMPLES_SRC})
 
     add_executable(${TRAGET_NAME} ${EXAMPLE_SRC} ${CORE_HEADERS})
     target_compile_options(${TRAGET_NAME} PUBLIC ${OPTS})
-    target_include_directories(${TRAGET_NAME} PUBLIC .. ${Boost_INCLUDE_DIRS})
+    target_include_directories(${TRAGET_NAME} PUBLIC ..)
 
     if (${OpenMP_CXX_FOUND})
-        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads ${Boost_LIBRARIES} OpenMP::OpenMP_CXX )
+        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads OpenMP::OpenMP_CXX )
     else()
-        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads ${Boost_LIBRARIES})
+        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads)
     endif ()
 
 endforeach(EXAMPLE_SRC)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,8 +14,12 @@ limitations under the License.]]
 
 file(GLOB EXAMPLES_SRC "*.cpp")
 
-if (${USE_OPENMP})
-    find_package(OpenMP REQUIRED)
+find_package(OpenMP)
+
+if (OpenMP_CXX_FOUND)
+    add_definitions(-DUSE_OPENMP)
+else()
+    message(WARNING "OpenMP could not be found. Building without threading support.")
 endif ()
 
 foreach(EXAMPLE_SRC ${EXAMPLES_SRC})
@@ -24,12 +28,12 @@ foreach(EXAMPLE_SRC ${EXAMPLES_SRC})
 
     add_executable(${TRAGET_NAME} ${EXAMPLE_SRC} ${CORE_HEADERS})
     target_compile_options(${TRAGET_NAME} PUBLIC ${OPTS})
-    target_include_directories(${TRAGET_NAME} PUBLIC ..)
+    target_include_directories(${TRAGET_NAME} PUBLIC .. ${Boost_INCLUDE_DIRS})
 
-    if (${USE_OPENMP})
-        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads OpenMP::OpenMP_CXX)
+    if (${OpenMP_CXX_FOUND})
+        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads ${Boost_LIBRARIES} OpenMP::OpenMP_CXX )
     else()
-        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads)
+        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads ${Boost_LIBRARIES})
     endif ()
 
 endforeach(EXAMPLE_SRC)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,35 @@
+#[[Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.]]
+
+file(GLOB EXAMPLES_SRC "*.cpp")
+
+if (${USE_OPENMP})
+    find_package(OpenMP REQUIRED)
+endif ()
+
+foreach(EXAMPLE_SRC ${EXAMPLES_SRC})
+    get_filename_component(TRAGET_NAME ${EXAMPLE_SRC} NAME_WE)
+    message(STATUS "Configuring ${TRAGET_NAME}")
+
+    add_executable(${TRAGET_NAME} ${EXAMPLE_SRC} ${CORE_HEADERS})
+    target_compile_options(${TRAGET_NAME} PUBLIC ${OPTS})
+    target_include_directories(${TRAGET_NAME} PUBLIC ..)
+
+    if (${USE_OPENMP})
+        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads OpenMP::OpenMP_CXX)
+    else()
+        target_link_libraries(${TRAGET_NAME} PUBLIC Threads::Threads)
+    endif ()
+
+endforeach(EXAMPLE_SRC)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(OpenMP)
 if (OpenMP_CXX_FOUND)
     add_definitions(-DUSE_OPENMP)
 else()
-    message(WARNING "OpenMP could not be found. Building without threading support.")
+    message(FATAL_ERROR "OpenMP could not be found. Aborting")
 endif ()
 
 foreach(EXAMPLE_SRC ${EXAMPLES_SRC})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,5 +14,5 @@ limitations under the License.]]
 
 add_executable(preprocess preprocess.cpp ${CORE_HEADERS})
 target_compile_options(preprocess PUBLIC ${OPTS})
-target_include_directories(preprocess PUBLIC ..)
-target_link_libraries(preprocess PUBLIC Threads::Threads)
+target_include_directories(preprocess PUBLIC .. ${Boost_INCLUDE_DIRS})
+target_link_libraries(preprocess PUBLIC Threads::Threads ${Boost_LIBRARIES})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,5 +14,5 @@ limitations under the License.]]
 
 add_executable(preprocess preprocess.cpp ${CORE_HEADERS})
 target_compile_options(preprocess PUBLIC ${OPTS})
-target_include_directories(preprocess PUBLIC .. ${Boost_INCLUDE_DIRS})
-target_link_libraries(preprocess PUBLIC Threads::Threads ${Boost_LIBRARIES})
+target_include_directories(preprocess PUBLIC ..)
+target_link_libraries(preprocess PUBLIC Threads::Threads)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,18 @@
+#[[Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.]]
+
+add_executable(preprocess preprocess.cpp ${CORE_HEADERS})
+target_compile_options(preprocess PUBLIC ${OPTS})
+target_include_directories(preprocess PUBLIC ..)
+target_link_libraries(preprocess PUBLIC Threads::Threads)

--- a/tools/preprocess.cpp
+++ b/tools/preprocess.cpp
@@ -14,14 +14,13 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
    limitations under the License.
 */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <unistd.h>
 #include <fcntl.h>
-#include <malloc.h>
-#include <errno.h>
-#include <assert.h>
-#include <string.h>
+#include <cerrno>
+#include <cassert>
+#include <cstring>
 
 #include <string>
 #include <vector>
@@ -36,6 +35,8 @@ Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
 #include "core/atomic.hpp"
 
 long PAGESIZE = 4096;
+
+#define memalign(alignment, size) malloc(size)
 
 void generate_edge_grid(std::string input, std::string output, VertexId vertices, int partitions, int edge_type) {
 	int parallelism = std::thread::hardware_concurrency();
@@ -267,8 +268,8 @@ void generate_edge_grid(std::string input, std::string output, VertexId vertices
 
 int main(int argc, char ** argv) {
 	int opt;
-	std::string input = "";
-	std::string output = "";
+	std::string input;
+	std::string output;
 	VertexId vertices = -1;
 	int partitions = -1;
 	int edge_type = 0;

--- a/tools/preprocess.cpp
+++ b/tools/preprocess.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2014-2015 Xiaowei Zhu, Tsinghua University
+Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/tools/preprocess.cpp
+++ b/tools/preprocess.cpp
@@ -37,8 +37,6 @@ Copyright (c) 2018 Hippolyte Barraud, Tsinghua University
 
 long PAGESIZE = 4096;
 
-#define memalign(alignment, size) malloc(size)
-
 void generate_edge_grid(std::string input, std::string output, VertexId vertices, int partitions, int edge_type) {
 	int parallelism = std::thread::hardware_concurrency();
 	int edge_unit;


### PR DESCRIPTION
**Description:**

I have made some minor modifications to GridGraph that allow compilation on all *NIX systems. In my case, OSX. I also fixed a lot of issues with the code that prevented it from compiling on modern compilers (no more errors/warnings)

This means dropping some APIs that the program linked against (like `fadvise` that is just a kernel-hint) or converting obsolete APIs to their POSIX-supported equivalent (such as `memalign` to `posix_memalign`).

I tried keeping the changes to a minimum, to avoid breaking anything.

The software is still incompatible with Windows systems (there's even a `system` call in `filesystem.hpp`...). I might give it a try later but the changes will be substantial.

The build system has been changed to CMake because people should be able to choose their toolchain (I prefer `Ninja`, for instance). The original `Makefile` is preserved in case somebody prefers that.

> OSX does not ship with OpenMP by default and the Apple-provided Clang compiler does not either. As a workaround, you can compile Clang yourself and set the `LLVM_TOOL_OPENMP_BUILD` Cmake variable to ON before generating, or install GCC that ship with OpenMP by default.

**How to:**

```
$ # In source directory
$ mkdir build && cd build
$ CXX=[PATH TO GCC IF NOT DEFAULT] cmake -DCMAKE_BUILD_TYPE=Release -D ..
$ make
```

The binaries are built into build/bin/

**Preview:**

[![asciicast](https://asciinema.org/a/uGr32mG5vHrDgYeDYBAejQr7u.png)](https://asciinema.org/a/uGr32mG5vHrDgYeDYBAejQr7u)